### PR TITLE
[feat] Add meta tag to generate OGP image for 2023 to use `https://gocon.jp`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="refresh" content="0;https://gocon.jp/2023/" />
+    <meta property="og:site_name" content="Go Conference 2023" />
+    <meta property="og:title" content="Go Conference 2023" />
+    <meta
+      property="og:description"
+      content="Go Conference is a conference for Go programming language users."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://gocon.jp/2023" />
+    <meta
+      property="og:image"
+      content="https://gocon.jp/2023/ogp-thumbnail.png"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
     <title>gocon.jp</title>
   </head>
   <body></body>


### PR DESCRIPTION
https://gocon.jp/2023 とサブパスまで含めないと OGP 画像が表示されないので、 https://gocon.jp で表示されるようにしたい。