### PR TITLE
feat: update `index.html` for 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,19 +2,19 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="refresh" content="0;https://gocon.jp/2024" />
-    <meta property="og:site_name" content="Go Conference 2024" />
-    <meta property="og:title" content="Go Conference 2024" />
+    <meta http-equiv="refresh" content="0;https://gocon.jp/2025" />
+    <meta property="og:site_name" content="Go Conference 2025" />
+    <meta property="og:title" content="Go Conference 2025" />
     <meta property="og:description" content="Go Conference is a conference for Go programming language users." />
-    <meta property="og:url" content="https://gocon.jp/2024" />
-    <meta property="og:image" content="https://gocon.jp/2024/og_image_lg.png" />
+    <meta property="og:url" content="https://gocon.jp/2025" />
+    <!-- <meta property="og:image" content="https://gocon.jp/2025/og_image_lg.png" /> -->
     <meta property="og:type" content="website" />
     <meta property="twitter:card" content="summary" />
-    <meta property="twitter:url" content="https://gocon.jp/2024" />
-    <meta property="twitter:title" content="Go Conference 2024" />
+    <meta property="twitter:url" content="https://gocon.jp/2025" />
+    <meta property="twitter:title" content="Go Conference 2025" />
     <meta property="twitter:description" content="Go Conference is a conference for Go programming language users." />
-    <meta property="twitter:image" content="https://gocon.jp/2024/og_image_md.png" />
-    <title>Go Conference 2024</title>
+    <!-- <meta property="twitter:image" content="https://gocon.jp/2025/og_image_md.png" /> -->
+    <title>Go Conference 2025</title>
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
Go Conference 2025 のために `index.html` の内容を更新しました。

- `og:image` と `twitter:image` はまだ用意がないため、コメントアウトしています
- このPRは、Go Conference 2025のウェブサイト（ティザーサイト）の公開をアナウンスする際にマージする必要があります
  - このPR作成時点で、すでに https://gocon.github.io/2025/ は https://gocon.jp/2025/ にリダイレクトされます